### PR TITLE
Rename test setup() setup_method()

### DIFF
--- a/ska_shell/tests/test_shell.py
+++ b/ska_shell/tests/test_shell.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.skipif(os.name == 'nt', reason='ska_shell not supported
 
 
 class TestSpawn:
-    def setup(self):
+    def setup_method(self):
         self.f = StringIO()
         self.g = StringIO()
 


### PR DESCRIPTION
## Description
Rename test setup() setup_method()

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Making the change per the warning directions gets rid of the warnings like this:

```
Ska/Shell/tests/test_shell.py::TestSpawn::test_shell_error
  /export/jgonzale/github-workflows/miniconda3/envs/ska3-masters-prime/lib/python3.10/site-packages/_pytest/fixtures.py:901: PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.
  Ska/Shell/tests/test_shell.py::TestSpawn::test_shell_error is using nose-specific method: `setup(self)`
  To remove this warning, rename it to `setup_method(self)`
  See docs: https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose
    fixture_result = next(generator)
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->

- [x] Mac


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
